### PR TITLE
Make sort key optional, support getItem, deleteItem and exists operations with partition key only

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,7 @@ Import DynamoHelper
 ```typescript
 import { DynamoHelper } from '@hitz-group/dynamo-helper';
 
-const { DynamoHelper} = require('@hitz-group/dynamo-helper');
-
+const { DynamoHelper } = require('@hitz-group/dynamo-helper');
 ```
 
 Use constructor to create the DynamoHelper instance
@@ -41,26 +40,27 @@ export interface TableConfig {
 import { DynamoHelper } from '@hitz-group/dynamo-helper';
 
 const table = {
- name: 'my-ddb-table',
- indexes: {
-   default: {
-     partitionKeyName: 'pk',
-     sortKeyName: 'sk',
-   }
- }
+  name: 'my-ddb-table',
+  indexes: {
+    default: {
+      partitionKeyName: 'pk',
+      sortKeyName: 'sk',
+    },
+  },
 };
 const client = new DynamoHelper(table, 'ap-south-1');
 
-await client.getItem('library#books', 'book-123');
+await client.getItem({ id: 'book-123' });
+await client.getItem({ pk: 'library#books', sk: 'book-123' });
+
 await client.query({
   where: {
     pk: 'library#books',
     publishedAt: {
-      between: [15550000, 15800000]
-    }
-  }
+      between: [15550000, 15800000],
+    },
+  },
 });
-
 ```
 
 ### buildQueryTableParams
@@ -68,7 +68,7 @@ await client.query({
 ```typescript
 import { buildQueryTableParams } from '@hitz-group/dynamo-helper';
 
-const { buildQueryTableParams} = require('@hitz-group/dynamo-helper');
+const { buildQueryTableParams } = require('@hitz-group/dynamo-helper');
 ```
 
 This method generates DynamoDB query input params from given filter object of type `Filter<T>`
@@ -175,12 +175,25 @@ const products = await dynamoHelper.query<ProductModel>({
 ### getItem
 
 Fetch an item using pk and sk combination. Returns item if found or returns null
+`getItem<T>(key: DocumentClient.Key, fields: Array<keyof T>)`
+
+#### key
+
+Required, at least partition key values must be provided.
+
+#### fields
+
+Optional, specify fields to project
 
 ```typescript
 import { getItem } from '@hitz-group/dynamo-helper';
 
 // Get a single product matching the key
-const product = await dynamoHelper.getItem<ProductModel>('org_uuid', 'product_xxx');
+await dynamoHelper.getItem<ProductModel>({ pk: 'org_uuid', sk: 'product_xxx' });
+await dynamoHelper.getItem<ProductModel>({ id: 'product_xxx' }, [
+  'id',
+  'isActive',
+]);
 ```
 
 ### batchGetItems
@@ -205,7 +218,7 @@ Check if an item exists in the database with the keys provided. Returns a boolea
 import { exists } from '@hitz-group/dynamo-helper';
 
 // Check if product already exists
-if (await dynamoHelper.exists('x', 1)) {
+if (await dynamoHelper.exists({ id: 'x' })) {
   console.log('exists');
 }
 ```
@@ -232,7 +245,7 @@ Remove an item from database matching the key provided if it exists
 import { deleteItem } from '@hitz-group/dynamo-helper';
 
 // delete product
-await dynamoHelper.deleteItem('x', '1'});
+await dynamoHelper.deleteItem({ id: '1' });
 ```
 
 ### transactPutItems

--- a/src/DynamoHelper.ts
+++ b/src/DynamoHelper.ts
@@ -45,11 +45,10 @@ export class DynamoHelper {
   }
 
   async getItem<T extends AnyObject>(
-    pk: string,
-    sk: string,
+    key: DocumentClient.Key,
     fields?: Array<keyof T>,
   ): Promise<T> {
-    return getItem(this.dbClient, this.table, pk, sk, fields);
+    return getItem(this.dbClient, this.table, key, fields);
   }
 
   async batchGetItems(
@@ -60,8 +59,8 @@ export class DynamoHelper {
     return batchGetItems(this.dbClient, this.table, keys, fields);
   }
 
-  async exists(pk: string, sk: string): Promise<boolean> {
-    return exists(this.dbClient, this.table, pk, sk);
+  async exists(key: DocumentClient.Key): Promise<boolean> {
+    return exists(this.dbClient, this.table, key);
   }
 
   async batchExists(
@@ -71,10 +70,9 @@ export class DynamoHelper {
   }
 
   async deleteItem(
-    pk: string,
-    sk: string,
+    key: DocumentClient.Key,
   ): Promise<PromiseResult<DeleteItemOutput, AWSError>> {
-    return deleteItem(this.dbClient, this.table, pk, sk);
+    return deleteItem(this.dbClient, this.table, key);
   }
 
   async batchDeleteItems(

--- a/src/query/exists.spec.ts
+++ b/src/query/exists.spec.ts
@@ -12,35 +12,29 @@ describe('exists', () => {
   });
 
   test('validates arguments', async () => {
-    await expect(exists(undefined, undefined)).rejects.toThrowError(
-      'Expected two arguments of type string, string received undefined, undefined',
+    await expect(exists(undefined)).rejects.toThrowError(
+      'Expected key to be of type object and not empty',
     );
-    await expect(exists(null, null)).rejects.toThrowError(
-      'Expected two arguments of type string, string received object, object',
+    await expect(exists(null)).rejects.toThrowError(
+      'Expected key to be of type object and not empty',
     );
-    await expect(exists('null', null)).rejects.toThrowError(
-      'Expected two arguments of type string, string received string, object',
-    );
-    await expect(exists(undefined, '')).rejects.toThrowError(
-      'Expected two arguments of type string, string received undefined, string',
+    await expect(exists('null')).rejects.toThrowError(
+      'Expected key to be of type object and not empty',
     );
     await expect(exists(2 as never, '')).rejects.toThrowError(
-      'Expected two arguments of type string, string received number, string',
-    );
-    await expect(exists('', '')).rejects.toThrowError(
-      'Expected both arguments to have length greater than 0',
+      'Expected key to be of type object and not empty',
     );
   });
 
   test('returns boolean value', async () => {
     // No results found, hence empty list.
     // getItem will return null in this case
-    await expect(exists('xxxx', 'yyyy')).resolves.toBe(false);
+    await expect(exists({ pk: 'xxxx', sk: 'yyyy' })).resolves.toBe(false);
 
     spy.mockReturnValue({
       promise: jest.fn().mockResolvedValue({ Item: { id: 'xxxx' } }),
     });
 
-    await expect(exists('xxxx', 'yyyy')).resolves.toBe(true);
+    await expect(exists({ pk: 'xxxx', sk: 'yyyy' })).resolves.toBe(true);
   });
 });

--- a/src/query/exists.ts
+++ b/src/query/exists.ts
@@ -11,9 +11,8 @@ import { TableConfig } from '../types';
 export async function exists(
   dbClient: DocumentClient,
   table: TableConfig,
-  pk: string,
-  sk: string
+  key: DocumentClient.Key,
 ): Promise<boolean> {
-  const item = await getItem(dbClient, table, pk, sk, ['id']);
+  const item = await getItem(dbClient, table, key, ['id']);
   return item ? true : false;
 }

--- a/src/query/getItem.ts
+++ b/src/query/getItem.ts
@@ -11,25 +11,23 @@ import { AnyObject, TableConfig } from '../types';
 export async function getItem<T extends AnyObject>(
   dbClient: DocumentClient,
   table: TableConfig,
-  pk: string,
-  sk: string,
-  fields?: Array<keyof T>
+  key: DocumentClient.Key,
+  fields?: Array<keyof T>,
 ): Promise<T> {
-  if (typeof pk !== 'string' || typeof sk !== 'string') {
-    throw new Error(
-      `Expected two arguments of type string, string received ${typeof pk}, ${typeof sk}`
-    );
-  } else if (!(pk && sk)) {
-    throw new Error('Expected both arguments to have length greater than 0');
-  }
-
   const index = table.indexes.default;
 
+  if (!key || typeof key !== 'object' || Object.keys(key).length === 0) {
+    throw new Error('Expected key to be of type object and not empty');
+  }
+
+  if (!key[index.partitionKeyName]) {
+    throw new Error(
+      'Invalid key: expected key to contain at least partition key',
+    );
+  }
+
   const params: DocumentClient.GetItemInput = {
-    Key: {
-      [index.partitionKeyName]: pk,
-      [index.sortKeyName]: sk,
-    },
+    Key: key,
     TableName: table.name,
   };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -160,7 +160,7 @@ export interface Filter<MT extends object = AnyObject> {
   limit?: number;
 }
 
-type TableIndex = { partitionKeyName: string; sortKeyName: string };
+type TableIndex = { partitionKeyName: string; sortKeyName?: string };
 
 export interface TableConfig {
   name: string;


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
- Makes sort key name optional in `TableIndex` when specifying `TableConfig`. This supports table with only partition key configured.
- getItem, deleteItem and exists now supports operations with only partition key or both keys.

Signature for `getItem`, `deleteItem` and `exists` has changed, now they accepts `key: DocumentClient.Key` instead of pk and sk as separate arguments.

```typescript
async getItem<T>( key: DocumentClient.Key,  fields?: Array<keyof T>): Promise<T>
```

example:

```typescript
client.getItem({ id: 'book-123' });
client.getItem({ pk: 'library#books', sk: 'book-123' }, ['id', 'isActive']);
```

## Related Issues
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: eg: #555-->
Issue: #3

## How Has This Been Tested
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
