### PR TITLE
Sorting order with ScanIndexForward

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,10 @@ export interface Filter<MT extends object = AnyObject> {
    * Maximum number of entities
    */
   limit?: number;
+  /**
+   * Sort order. Only works with sort keys
+   */
+  order?: 'ascending' | 'descending';
 }
 ```
 

--- a/src/query/queryBuilder.spec.ts
+++ b/src/query/queryBuilder.spec.ts
@@ -6,7 +6,7 @@ type ProductModel = {
   id: string;
   isActive: boolean;
   barcode?: string;
-}
+};
 
 const sampleCases = [
   {
@@ -588,6 +588,35 @@ describe('Query Builder', () => {
       limit: 5,
     });
     expect(tableParams.Limit).toBe(5);
+  });
+
+  test('sort order', () => {
+    let tableParams = buildQueryTableParams<ProductModel>({
+      where: {
+        pk: 'xxxx',
+        sk: 'yyyy',
+      },
+    });
+
+    expect(tableParams).not.toHaveProperty('ScanIndexForward');
+
+    tableParams = buildQueryTableParams<ProductModel>({
+      where: {
+        pk: 'xxxx',
+        sk: 'yyyy',
+      },
+      order: 'descending',
+    });
+    expect(tableParams.ScanIndexForward).toBe(false);
+
+    tableParams = buildQueryTableParams<ProductModel>({
+      where: {
+        pk: 'xxxx',
+        sk: 'yyyy',
+      },
+      order: 'ascending',
+    });
+    expect(tableParams.ScanIndexForward).toBe(true);
   });
 
   sampleCases.forEach(x => {

--- a/src/query/queryBuilder.ts
+++ b/src/query/queryBuilder.ts
@@ -240,5 +240,12 @@ export function buildQueryTableParams<T extends object = AnyObject>(
     tableParams.Limit = filter.limit;
   }
 
+  // Specifies the order for index traversal
+  // If true (default),the traversal is performed in ascending order
+  // if false, the traversal is performed in descending order.
+  if (filter.order) {
+    tableParams.ScanIndexForward = filter.order === 'ascending';
+  }
+
   return tableParams;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -159,7 +159,7 @@ export interface Filter<MT extends object = AnyObject> {
    */
   limit?: number;
   /**
-   * Sort order
+   * Sort order. Only works with sort keys
    */
   order?: 'ascending' | 'descending';
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -158,6 +158,10 @@ export interface Filter<MT extends object = AnyObject> {
    * Maximum number of entities
    */
   limit?: number;
+  /**
+   * Sort order
+   */
+  order?: 'ascending' | 'descending';
 }
 
 type TableIndex = { partitionKeyName: string; sortKeyName?: string };


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Implemented sorting order functionality.
`order: 'ascending' | 'descending'`

**ScanIndexForward**
> Specifies the order for index traversal: If true (default), the traversal is performed in ascending order; if false, the traversal is performed in descending order.
Items with the same partition key value are stored in sorted order by sort key. If the sort key data type is Number, the results are stored in numeric order. For type String, the results are stored in order of UTF-8 bytes. For type Binary, DynamoDB treats each byte of the binary data as unsigned.
If ScanIndexForward is true, DynamoDB returns the results in the order in which they are stored (by sort key value). This is the default behavior. If ScanIndexForward is false, DynamoDB reads the results in reverse order by sort key value, and then returns the results to the client.

## How Has This Been Tested
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.