### PR TITLE
Query based pagination

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ export interface Filter<MT extends object = AnyObject> {
   /**
    * Sort order. Only works with sort keys
    */
-  order?: 'ascending' | 'descending';
+  orderBy?: Direction;
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -163,6 +163,48 @@ const products = await dynamoHelper.query<ProductModel>({
 });
 ```
 
+### pginated based query (cursor)
+
+- DynamoDB official docs - [Paginate table query result](https://docs.amazonaws.cn/en_us/amazondynamodb/latest/developerguide/Query.Pagination.html) and [Query](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_Query.html)
+- To use this method, the table must have a `range key` associated to partition key
+- Using the method from this library (`queryWithCursor`)
+  Example 1:
+
+```tsx
+// Paginate with a custom page size (refer to AWS DynamoDB docs to check the max size / limit)
+// Get first `6` organizations (DynamoDB default sort order will be ascending)
+const resultForFirstIterationOrPage = await query({
+  where: {
+    pk: 'org_uuid',
+  },
+  limit: 6,
+});
+
+// The next `6` orgs can be retrived based on the `cursor` value (from previous response)
+const resultForFirstIterationOrPage = await query({
+  where: {
+    pk: 'org_uuid',
+  },
+  limit: 6,
+  prevCursor: result.cursor,
+});
+
+// The same step can be repeated until the `cursor` returns `undefined`
+```
+
+Example 2:
+
+```tsx
+// Sort the results in reverse order with a page size `7`- descending
+const result = await query({
+  where: {
+    pk: 'org_uuid',
+  },
+  limit: 7,
+  orderBy: Direction.DESC,
+});
+```
+
 #### Supported filter operators
 
 - `eq`

--- a/package.json
+++ b/package.json
@@ -37,12 +37,14 @@
   },
   "dependencies": {
     "aws-sdk": "2.784.0",
+    "crypto-js": "^4.0.0",
     "lodash": "4.17.20"
   },
   "devDependencies": {
     "@babel/core": "7.12.1",
     "@babel/preset-env": "7.12.1",
     "@babel/preset-typescript": "7.12.1",
+    "@types/crypto-js": "^4.0.1",
     "@types/jest": "26.0.15",
     "@typescript-eslint/eslint-plugin": "4.6.1",
     "@typescript-eslint/parser": "4.6.1",

--- a/src/DynamoHelper.ts
+++ b/src/DynamoHelper.ts
@@ -18,12 +18,7 @@ import { exists } from './query/exists';
 import { getItem } from './query/getItem';
 import { query } from './query/query';
 import { queryWithCursor } from './query/queryWithCursor';
-import {
-  AnyObject,
-  Filter,
-  QueryWithCursorOptions,
-  TableConfig,
-} from './types';
+import { AnyObject, Filter, TableConfig } from './types';
 
 export class DynamoHelper {
   table: TableConfig;
@@ -52,9 +47,9 @@ export class DynamoHelper {
 
   async queryWithCursor<T extends AnyObject>(
     filter: Filter<T>,
-    options: QueryWithCursorOptions,
+    indexName?: string,
   ): Promise<{ items: Array<T>; cursor?: string }> {
-    return queryWithCursor(this.dbClient, this.table, filter, options);
+    return queryWithCursor(this.dbClient, this.table, filter, indexName);
   }
 
   async getItem<T extends AnyObject>(

--- a/src/DynamoHelper.ts
+++ b/src/DynamoHelper.ts
@@ -17,7 +17,13 @@ import { batchGetItems } from './query/batchGetItems';
 import { exists } from './query/exists';
 import { getItem } from './query/getItem';
 import { query } from './query/query';
-import { AnyObject, Filter, TableConfig } from './types';
+import { queryWithCursor } from './query/queryWithCursor';
+import {
+  AnyObject,
+  Filter,
+  QueryWithCursorOptions,
+  TableConfig,
+} from './types';
 
 export class DynamoHelper {
   table: TableConfig;
@@ -42,6 +48,13 @@ export class DynamoHelper {
     indexName?: string,
   ): Promise<Array<T>> {
     return query(this.dbClient, this.table, filter, indexName);
+  }
+
+  async queryWithCursor<T extends AnyObject>(
+    filter: Filter<T>,
+    options: QueryWithCursorOptions,
+  ): Promise<{ items: Array<T>; cursor?: string }> {
+    return queryWithCursor(this.dbClient, this.table, filter, options);
   }
 
   async getItem<T extends AnyObject>(

--- a/src/query/queryBuilder.spec.ts
+++ b/src/query/queryBuilder.spec.ts
@@ -1,3 +1,4 @@
+import { Direction } from '../types';
 import { buildQueryTableParams } from './queryBuilder';
 
 type ProductModel = {
@@ -605,7 +606,7 @@ describe('Query Builder', () => {
         pk: 'xxxx',
         sk: 'yyyy',
       },
-      order: 'descending',
+      orderBy: Direction.DESC,
     });
     expect(tableParams.ScanIndexForward).toBe(false);
 
@@ -614,7 +615,7 @@ describe('Query Builder', () => {
         pk: 'xxxx',
         sk: 'yyyy',
       },
-      order: 'ascending',
+      orderBy: Direction.ASC,
     });
     expect(tableParams.ScanIndexForward).toBe(true);
   });

--- a/src/query/queryBuilder.ts
+++ b/src/query/queryBuilder.ts
@@ -5,6 +5,7 @@ import {
   FilterOperators,
   Where,
   QueryInput,
+  Direction,
 } from '../types';
 
 /**
@@ -243,8 +244,8 @@ export function buildQueryTableParams<T extends object = AnyObject>(
   // Specifies the order for index traversal
   // If true (default),the traversal is performed in ascending order
   // if false, the traversal is performed in descending order.
-  if (filter.order) {
-    tableParams.ScanIndexForward = filter.order === 'ascending';
+  if (filter.orderBy) {
+    tableParams.ScanIndexForward = filter.orderBy === Direction.ASC;
   }
 
   return tableParams;

--- a/src/query/queryWithCursor.spec.ts
+++ b/src/query/queryWithCursor.spec.ts
@@ -1,0 +1,382 @@
+import {
+  ItemList,
+  Key,
+  QueryInput,
+  QueryOutput,
+} from 'aws-sdk/clients/dynamodb';
+import { testClient, testTableConf } from '../testUtils';
+import { Direction, Where } from '../types';
+import { queryWithCursor } from './queryWithCursor';
+import { decrypt } from '../utils';
+
+describe('queryWithCursor', () => {
+  const query = queryWithCursor.bind(null, testClient, testTableConf);
+  let mockQuery: jest.SpyInstance;
+  beforeEach(() => {
+    mockQuery = jest.spyOn(testClient, 'query').mockReturnValue({
+      promise: jest
+        .fn()
+        .mockResolvedValue({ Items: [], LastEvaluatedKey: undefined }),
+    });
+  });
+
+  afterEach(() => {
+    mockQuery.mockReset();
+  });
+
+  test('input validation', async () => {
+    const queryWithoutSk = queryWithCursor.bind(null, testClient, {
+      ...testTableConf,
+      indexes: {
+        ...testTableConf.indexes,
+        default: {
+          partitionKeyName: 'pk',
+        },
+      },
+    });
+    await expect(
+      queryWithoutSk({
+        where: {
+          pk: 'xxxx',
+        },
+      }),
+    ).rejects.toThrowError('Expected sortKey to query');
+
+    expect(testClient.query).toHaveBeenCalledTimes(0);
+  });
+
+  test('input validation', async () => {
+    await expect(
+      query(
+        {
+          where: {
+            pk: {
+              beginsWith: 'product',
+            },
+          } as Where<{ pk: string }>,
+        },
+        { secret: 'secret' },
+      ),
+    ).rejects.toThrowError('Partition key condition can only be a string');
+  });
+
+  test('input validation', async () => {
+    await expect(
+      query({
+        where: {
+          pk: 'product',
+        } as Where<{ pk: string }>,
+      }),
+    ).rejects.toThrowError(
+      'Expected secret which is used to encrypt the `LastEvaluatedKey`',
+    );
+  });
+
+  test('when there are no items available in table, returns empty', async () => {
+    const results = await query(
+      {
+        where: {
+          pk: 'xxxx',
+        },
+      },
+      { secret: 'secret' },
+    );
+
+    expect(results.items).toHaveLength(0);
+    expect(results.cursor).toBeUndefined();
+  });
+
+  test('with index name specified', () => {
+    query(
+      {
+        where: {
+          sk: 'xxxx',
+        },
+      },
+      {
+        indexName: 'reverse',
+        secret: 'secret',
+      },
+    );
+
+    expect(testClient.query).toHaveBeenCalledWith({
+      TableName: testTableConf.name,
+      IndexName: 'reverse',
+      KeyConditionExpression: '#SK = :sk',
+      ExpressionAttributeNames: {
+        '#SK': 'sk',
+      },
+      ExpressionAttributeValues: {
+        ':sk': 'xxxx',
+      },
+      ExclusiveStartKey: undefined,
+    });
+  });
+});
+
+interface Item {
+  pk: string;
+  sk: string;
+}
+const TOTAL_RECORDS = 50;
+
+const ITEMS = new Array(TOTAL_RECORDS).fill(0).map((item, i) => {
+  const date = new Date(2021, Math.floor(Math.random() * 6) + 1, i);
+  return {
+    pk: `pk#${item}`,
+    sk: `sk#${date.getFullYear()}#${date.getMonth()}#${date.getDate()}`,
+  };
+});
+class DbQuery {
+  private _records = ITEMS;
+
+  get records(): Item[] {
+    return this._records;
+  }
+  set records(value: Item[]) {
+    this._records = value;
+  }
+
+  public sortItems(params: QueryInput) {
+    if (
+      typeof params.ScanIndexForward !== 'undefined' &&
+      params.ScanIndexForward === false
+    ) {
+      this.records.sort((a, b) => b.sk.localeCompare(a.sk));
+    } else {
+      this.records.sort((a, b) => a.sk.localeCompare(b.sk));
+    }
+    return this;
+  }
+
+  public filterItems(params: QueryInput, size: number) {
+    if (params.ExclusiveStartKey) {
+      const { pk, sk } = params.ExclusiveStartKey;
+      const position = this.records.findIndex(e => e.pk === pk && e.sk === sk);
+      return {
+        processed: position + 1,
+        items: this.records.slice(position + 1, position + 1 + size),
+      };
+    }
+    return { processed: 0, items: this.records.slice(0, size) };
+  }
+}
+
+describe('Pagination', () => {
+  let mockQuery: jest.SpyInstance;
+  const query = queryWithCursor.bind(null, testClient, testTableConf);
+
+  beforeEach(() => {
+    mockQuery = jest
+      .spyOn(testClient, 'query')
+      .mockImplementation((params: QueryInput) => {
+        const { items, processed } = new DbQuery()
+          .sortItems(params)
+          .filterItems(params, params.Limit);
+
+        let lastEvaluatedKey;
+        if (params.Limit) {
+          lastEvaluatedKey =
+            processed + items.length >= TOTAL_RECORDS
+              ? undefined
+              : items[items.length - 1];
+        }
+
+        return {
+          promise: jest.fn().mockImplementation(() => {
+            return Promise.resolve({
+              Items: (items as unknown) as ItemList,
+              LastEvaluatedKey: lastEvaluatedKey,
+            } as QueryOutput);
+          }),
+        };
+      });
+  });
+
+  afterEach(() => {
+    mockQuery.mockReset();
+  });
+
+  test('with default page size (all items) and sort order', async () => {
+    const result = await query(
+      {
+        where: { pk: 'xxxx' },
+      },
+      {
+        secret: 'secret',
+      },
+    );
+    expect(testClient.query).toHaveBeenCalledTimes(1);
+    expect(result.items).toHaveLength(50);
+    expect(result.cursor).toBeUndefined();
+    expect(testClient.query).toHaveBeenNthCalledWith(1, {
+      TableName: testTableConf.name,
+      IndexName: 'default',
+      KeyConditionExpression: '#PK = :pk',
+      ExpressionAttributeNames: {
+        '#PK': 'pk',
+      },
+      ExpressionAttributeValues: {
+        ':pk': 'xxxx',
+      },
+      ExclusiveStartKey: undefined,
+    });
+    expect(result.items[0]).toStrictEqual(
+      ITEMS.sort((a, b) => a.sk.localeCompare(b.sk))[0],
+    );
+  });
+
+  test('with customm page size', async () => {
+    const result = await query(
+      {
+        where: {
+          pk: 'xxxx',
+        },
+        limit: 5,
+      },
+      {
+        secret: 'secret',
+      },
+    );
+    expect(testClient.query).toHaveBeenCalledTimes(1);
+    expect(result.items).toHaveLength(5);
+    expect(typeof result.cursor).toBe('string');
+    expect(testClient.query).toHaveBeenNthCalledWith(1, {
+      TableName: testTableConf.name,
+      IndexName: 'default',
+      KeyConditionExpression: '#PK = :pk',
+      ExpressionAttributeNames: {
+        '#PK': 'pk',
+      },
+      ExpressionAttributeValues: {
+        ':pk': 'xxxx',
+      },
+      ExclusiveStartKey: undefined,
+      Limit: 5,
+    });
+  });
+
+  test('with customm page size and custom orderBy ', async () => {
+    const result = await query(
+      {
+        where: {
+          pk: 'xxxx',
+        },
+        limit: 5,
+        orderBy: Direction.DESC,
+      },
+      {
+        secret: 'secret',
+      },
+    );
+    expect(testClient.query).toHaveBeenCalledTimes(1);
+    expect(result.items).toHaveLength(5);
+    expect(typeof result.cursor).toBe('string');
+    expect(testClient.query).toHaveBeenNthCalledWith(1, {
+      TableName: testTableConf.name,
+      IndexName: 'default',
+      KeyConditionExpression: '#PK = :pk',
+      ExpressionAttributeNames: {
+        '#PK': 'pk',
+      },
+      ExpressionAttributeValues: {
+        ':pk': 'xxxx',
+      },
+      ExclusiveStartKey: undefined,
+      Limit: 5,
+      ScanIndexForward: false,
+    });
+    expect(result.items[0]).toStrictEqual(
+      ITEMS.sort((a, b) => b.sk.localeCompare(a.sk))[0],
+    );
+  });
+
+  test('initial request with custom page size', async () => {
+    const result = await query(
+      {
+        where: {
+          pk: 'xxxx',
+        },
+        limit: 5,
+      },
+      {
+        secret: 'secret',
+      },
+    );
+    expect(testClient.query).toHaveBeenCalledTimes(1);
+    expect(result.items).toHaveLength(5);
+    expect(typeof result.cursor).toBe('string');
+    expect(testClient.query).toHaveBeenNthCalledWith(1, {
+      TableName: testTableConf.name,
+      IndexName: 'default',
+      KeyConditionExpression: '#PK = :pk',
+      ExpressionAttributeNames: {
+        '#PK': 'pk',
+      },
+      ExpressionAttributeValues: {
+        ':pk': 'xxxx',
+      },
+      ExclusiveStartKey: undefined,
+      Limit: 5,
+    });
+  });
+
+  test('returns result for sub-sequent query based on prevCursor', async () => {
+    const PAGE_SIZE = 5;
+    let prevCursor,
+      items = [],
+      i = 1;
+
+    const actualItems = ITEMS.sort((a, b) => a.sk.localeCompare(b.sk));
+    do {
+      const result = await query(
+        {
+          where: {
+            pk: 'xxxx',
+          },
+          limit: PAGE_SIZE,
+        },
+        {
+          secret: 'secret',
+          prevCursor,
+        },
+      );
+
+      expect(testClient.query).toHaveBeenNthCalledWith(i, {
+        TableName: testTableConf.name,
+        IndexName: 'default',
+        KeyConditionExpression: '#PK = :pk',
+        ExpressionAttributeNames: {
+          '#PK': 'pk',
+        },
+        ExpressionAttributeValues: {
+          ':pk': 'xxxx',
+        },
+        ExclusiveStartKey: decrypt<Key>(prevCursor, 'secret'),
+        Limit: 5,
+      });
+
+      if (items.length > 0) {
+        const { pk, sk } = items[items.length - 1];
+        const position = actualItems.findIndex(e => e.pk === pk && e.sk === sk);
+
+        expect(result.items).toStrictEqual(
+          actualItems.slice(position + 1, position + 1 + PAGE_SIZE),
+        );
+      } else {
+        expect(result.items).toStrictEqual(actualItems.slice(0, 5));
+      }
+
+      items = items.concat(result.items);
+
+      prevCursor = result.cursor;
+      i++;
+    } while (prevCursor);
+
+    expect(testClient.query).toHaveBeenCalledTimes(
+      Math.ceil(TOTAL_RECORDS / PAGE_SIZE),
+    );
+    expect(items).toHaveLength(50);
+    expect(prevCursor).toBeUndefined();
+  });
+});

--- a/src/query/queryWithCursor.spec.ts
+++ b/src/query/queryWithCursor.spec.ts
@@ -127,7 +127,7 @@ const ITEMS = new Array(TOTAL_RECORDS).fill(0).map((item, i) => {
     }`,
   };
 });
-class DbQuery {
+class DynamoDBPaginateQueryMockImpl {
   private _records = ITEMS;
 
   get records(): Item[] {
@@ -173,7 +173,10 @@ describe('Pagination', () => {
     mockQuery = jest
       .spyOn(testClient, 'query')
       .mockImplementation((params: QueryInput) => {
-        const { items, processed } = new DbQuery()
+        const {
+          items,
+          processed,
+        } = new DynamoDBPaginateQueryMockImpl()
           .sortItems(params)
           .filterItems(params, params.Limit);
 

--- a/src/query/queryWithCursor.ts
+++ b/src/query/queryWithCursor.ts
@@ -1,0 +1,53 @@
+import { DocumentClient, Key, QueryOutput } from 'aws-sdk/clients/dynamodb';
+import { decrypt, encrypt } from '../utils';
+import {
+  AnyObject,
+  Filter,
+  QueryWithCursorOptions,
+  TableConfig,
+} from '../types';
+import { buildQueryTableParams } from './queryBuilder';
+
+/**
+ * Cursor based query which returns list of matching items and the last cursor position
+ *
+ * @param {Filter<T>} filter query filter
+ * @param { QueryWithCursorOptions } options cursor, page size options
+ * @returns {Array<T>, string} list of matching items, last cursor position
+ */
+export async function queryWithCursor<T extends AnyObject>(
+  dbClient: DocumentClient,
+  table: TableConfig,
+  filter: Filter<T>,
+  options: QueryWithCursorOptions,
+): Promise<{ items: Array<T>; cursor?: string }> {
+  const { indexName = 'default', prevCursor, secret } = options || {};
+  const { partitionKeyName, sortKeyName } = table.indexes[indexName];
+
+  if (!sortKeyName) {
+    throw new Error('Expected sortKey to query');
+  }
+
+  if (!secret) {
+    throw new Error(
+      'Expected secret which is used to encrypt the `LastEvaluatedKey`',
+    );
+  }
+
+  const params = buildQueryTableParams(filter, partitionKeyName, sortKeyName);
+
+  params.TableName = table.name;
+  if (indexName) {
+    params.IndexName = indexName;
+  }
+  params.ExclusiveStartKey = decrypt<Key>(prevCursor, secret);
+
+  const { LastEvaluatedKey, Items }: QueryOutput = await dbClient
+    .query(params)
+    .promise();
+
+  return {
+    items: Items as T[],
+    cursor: encrypt<Key>(LastEvaluatedKey, secret),
+  };
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -165,6 +165,11 @@ export interface Filter<MT extends object = AnyObject> {
    * Sort order. Only works with sort keys
    */
   orderBy?: Direction;
+
+  /**
+   * Only be used with cursor based `query`
+   */
+  prevCursor?: string;
 }
 
 type TableIndex = { partitionKeyName: string; sortKeyName?: string };
@@ -178,10 +183,5 @@ export interface TableConfig {
    * eg: indexes: { default: { partitionKeyName: 'pk', sortKeyName: 'sk' } }
    */
   indexes: { default: TableIndex } & Record<string, TableIndex>;
-}
-
-export interface QueryWithCursorOptions {
-  indexName?: string;
-  prevCursor?: string; // the last cursor position
-  secret: string; // used to encrypt cursor
+  cursorSecret?: string; // used to mask the lastEvaluatedKey in query result
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -132,7 +132,10 @@ export interface OrClause<MT extends object> {
 /**
  * Order by direction
  */
-export type Direction = 'ASC' | 'DESC';
+export enum Direction {
+  ASC = 'ASC',
+  DESC = 'DESC',
+}
 
 /**
  * Selection of fields
@@ -161,7 +164,7 @@ export interface Filter<MT extends object = AnyObject> {
   /**
    * Sort order. Only works with sort keys
    */
-  order?: 'ascending' | 'descending';
+  orderBy?: Direction;
 }
 
 type TableIndex = { partitionKeyName: string; sortKeyName?: string };
@@ -175,4 +178,10 @@ export interface TableConfig {
    * eg: indexes: { default: { partitionKeyName: 'pk', sortKeyName: 'sk' } }
    */
   indexes: { default: TableIndex } & Record<string, TableIndex>;
+}
+
+export interface QueryWithCursorOptions {
+  indexName?: string;
+  prevCursor?: string; // the last cursor position
+  secret: string; // used to encrypt cursor
 }

--- a/src/utils.spec.ts
+++ b/src/utils.spec.ts
@@ -1,0 +1,22 @@
+import { decrypt, encrypt } from './utils';
+
+describe('utils', () => {
+  test('encrypt returns undefined for undefined input', () => {
+    const value = encrypt(undefined, 'secret');
+    expect(value).toBeUndefined();
+  });
+  test('decrypt returns undefined for undefined input', () => {
+    const value = decrypt(undefined, 'secret');
+    expect(value).toBeUndefined();
+  });
+  test('encrypt & decrypts the string', () => {
+    const masked = encrypt('Hello World!', 'secret');
+    const unmasked = decrypt(masked, 'secret');
+    expect(unmasked).toBe('Hello World!');
+  });
+  test('encrypt & decrypts the object', () => {
+    const masked = encrypt({ message: 'Hello World!' }, 'secret');
+    const unmasked = decrypt(masked, 'secret');
+    expect(unmasked).toStrictEqual({ message: 'Hello World!' });
+  });
+});

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,29 @@
+import CryptoJS from 'crypto-js';
+
+/**
+ *
+ * @param value
+ * @param secret
+ * @returns
+ */
+export const encrypt = <T>(value: T, secret: string): string => {
+  if (value || typeof value !== 'undefined') {
+    return CryptoJS.AES.encrypt(JSON.stringify({ value }), secret).toString();
+  }
+  return undefined;
+};
+
+/**
+ *
+ * @param value
+ * @param secret
+ * @returns
+ */
+export const decrypt = <T>(value: string, secret: string): T => {
+  if (!value) {
+    return undefined;
+  }
+  const wordArray = CryptoJS.AES.decrypt(value, secret);
+  const json = JSON.parse(wordArray.toString(CryptoJS.enc.Utf8));
+  return json.value;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1308,6 +1308,11 @@
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
   integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
 
+"@types/crypto-js@^4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@types/crypto-js/-/crypto-js-4.0.1.tgz#3a4bd24518b0e6c5940da4e2659eeb2ef0806963"
+  integrity sha512-6+OPzqhKX/cx5xh+yO8Cqg3u3alrkhoxhE5ZOdSEv0DOzJ13lwJ6laqGU0Kv6+XDMFmlnGId04LtY22PsFLQUw==
+
 "@types/graceful-fs@^4.1.2":
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/@types/graceful-fs/-/graceful-fs-4.1.3.tgz#039af35fe26bec35003e8d86d2ee9c586354348f"
@@ -2054,6 +2059,11 @@ cross-spawn@^7.0.0, cross-spawn@^7.0.2:
     path-key "^3.1.0"
     shebang-command "^2.0.0"
     which "^2.0.1"
+
+crypto-js@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/crypto-js/-/crypto-js-4.0.0.tgz#2904ab2677a9d042856a2ea2ef80de92e4a36dcc"
+  integrity sha512-bzHZN8Pn+gS7DQA6n+iUmBfl0hO5DJq++QP3U6uTucDtk/0iGpXd/Gg7CGR0p8tJhofJyaKoWBuJI4eAO00BBg==
 
 cssom@^0.4.4:
   version "0.4.4"


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Queries records with
 - A page limit
 - Cursor (lastEvaluatedKey)
Replaces `ascending` and `descending` with `Direction` enum to sort the query results
Rename `order` to `orderBy`

Cursor tells the last processed item and this will be varied based on applied filters.
Masks the cursor to hide the actual db implementation details (partition key and range key).
Uses `crypto-js` to encrypt and decrypt the cursor.

Example:

```tsx
const dynamoHelper = new DynamoHelper({...tableConf, cursorSecret: 'somesecret'}, region, endpoint);
const result = await dynamoHelper.queryWithCursor({
        where: {
          pk: 'partition_key',
          sk: 'sort_key',
        },
        limit: 10,
        prevCursor,
        orderBy: Direction.DESC
});


```

## Related Issues
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: eg: #555-->
Issue: #XXX

## How Has This Been Tested
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## Screenshots (if appropriate)
