### PR TITLE
In Operator support for more than 100 operands

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dynamo",
     "nosql"
   ],
-  "version": "0.4.9",
+  "version": "0.4.10",
   "files": [
     "lib",
     "LICENSE",

--- a/src/query/queryBuilder.spec.ts
+++ b/src/query/queryBuilder.spec.ts
@@ -9,6 +9,14 @@ type ProductModel = {
   barcode?: string;
 };
 
+const expressionForMoreThan100Values = () => {
+  const obj = {};
+  Array.from(Array(200).keys()).forEach(val => {
+    obj[`:id${val + 1}`] = val;
+  });
+  return obj;
+};
+
 const sampleCases = [
   {
     name: 'sk operations: between',
@@ -252,6 +260,35 @@ const sampleCases = [
         ':pk': 'xxxx',
         ':id1': 'yyyy',
         ':id2': 'zzzz',
+      },
+    },
+  },
+  {
+    name: 'filter conditions: includes for more than 100 ids',
+    filter: {
+      where: {
+        pk: 'xxxx',
+        id: {
+          inq: Array.from(Array(200).keys()),
+        },
+      },
+    },
+    expected: {
+      KeyConditionExpression: '#PK = :pk',
+      // FilterExpression: '#ID in (:id1, :id2)',
+      FilterExpression: `#ID in (${Array.from(Array(100).keys())
+        .map(x => `:id${x + 1}`)
+        .join(', ')}) AND OR #ID in (${Array.from(Array(200).keys())
+        .slice(100)
+        .map(x => `:id${x + 1}`)
+        .join(', ')})`,
+      ExpressionAttributeNames: {
+        '#PK': 'pk',
+        '#ID': 'id',
+      },
+      ExpressionAttributeValues: {
+        ':pk': 'xxxx',
+        ...expressionForMoreThan100Values(),
       },
     },
   },

--- a/src/query/queryBuilder.ts
+++ b/src/query/queryBuilder.ts
@@ -169,21 +169,21 @@ function buildConditionExpressions<T extends object = AnyObject>(
         const arraysOfContaingMax100Values = [];
         let tempArray = [];
         condition.forEach((eachVal, index) => {
-          if ((index + 1) % 100 === 0) {
+          tempArray.push(eachVal);
+          if (
+            (index + 1) % 100 === 0 ||
+            (condition.length < 100 && index + 1 === condition.length)
+          ) {
             arraysOfContaingMax100Values.push(tempArray);
             tempArray = [];
-          } else if (condition.length < 100 && index + 1 === condition.length) {
-            tempArray.push(eachVal);
-            arraysOfContaingMax100Values.push(tempArray);
-          } else {
-            tempArray.push(eachVal);
           }
         });
         arraysOfContaingMax100Values.forEach(
           (eachArrayWith100Values, indexOfAllArraysOf100Values) => {
+            expressionTemp = '';
             eachArrayWith100Values.forEach((eachVal, indexOfCondition) => {
               const index =
-                (indexOfAllArraysOf100Values + 1) * indexOfCondition;
+                indexOfAllArraysOf100Values * 100 + indexOfCondition;
               expressionAttributeValues[
                 `${valueExpression}${index + 1}`
               ] = eachVal;


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

- [X] `IN` operator support for more than 100 operands

Why this is needed (usecase):

for example:

when we filter by payment type we are getting all orders by that payment type and doing like below

id inq [...all those order ids filtered by payment type]

**The maximum number of operands for the IN comparator is 100**
Ref: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Limits.html#limits-expression-parameters




## Related Issues
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: eg: #555-->
Issue: #XXX

## How Has This Been Tested
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

## Screenshots (if appropriate)
