### PR TITLE
ci: publish to npm on tags instead

### DIFF
--- a/.github/workflows/github-publish.yml
+++ b/.github/workflows/github-publish.yml
@@ -3,20 +3,19 @@ name: github-publish
 on:
   workflow_dispatch:
   push:
-    branches:
-      - 'master'
+    tags:
+      - 'v*.*.*'
 
 jobs:
   github-publish:
     name: github-publish
     runs-on: ubuntu-latest
-    if: contains( github.event.head_commit.message, 'Release***')
     steps:
     - name: Checkout repository
       uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: "14.x"
+        node-version: 14
         registry-url: "https://npm.pkg.github.com"
         scope: "@hitz-group"
     - name: Install Node Dependencies

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,8 +1,8 @@
 name: npm-publish
 on:
   push:
-    branches:
-      - master
+    tags:
+      - 'v*.*.*'
 jobs:
   npm-publish:
     name: npm-publish

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -8,7 +8,6 @@ jobs:
   npm-publish:
     name: npm-publish
     runs-on: ubuntu-latest
-    if: contains( github.event.head_commit.message, 'Release***')
     steps:
     - name: Checkout repository
       uses: actions/checkout@v3
@@ -22,6 +21,7 @@ jobs:
       run: yarn build
       env:
         CI: "TRUE"
-    - run: npm publish --access public
+    - name: Publish package
+      run: npm publish --access public
       env:
         NODE_AUTH_TOKEN: ${{secrets.NPM_AUTH_TOKEN}}


### PR DESCRIPTION
Publishing on push to master is not scalable without e2e tests. Currently PR authors are bumping versions for themself and it will cause conflicts when a PR wants to change minor version when other changes patch

## Description
<!--- Describe your changes in detail -->

## Related Issues
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: eg: #555-->
Issue: #XXX

## How Has This Been Tested
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## Screenshots (if appropriate)
